### PR TITLE
feat: add ResponsePreprocessor hook for raw XML sanitization

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,6 +167,12 @@ type Client struct {
 	logger            Logger
 	prettyPrintLogs   bool
 	redactionPatterns []*regexp.Regexp
+
+	// ResponsePreprocessor is an optional function that transforms the raw XML
+	// response string before it is parsed by xmldot. This allows callers to
+	// sanitize malformed XML (e.g., unescaped angle brackets in banner text)
+	// before the parser sees it.
+	ResponsePreprocessor func(string) string
 }
 
 // NewClient creates a new NETCONF client with the specified host and options
@@ -1975,18 +1981,24 @@ func (c *Client) executeCommit(req *Req) (*response.NetconfResponse, error) {
 // Returns a Res struct with parsed data or an error if parsing fails.
 func (c *Client) parseResponse(scrapligoRes *response.NetconfResponse) (Res, error) {
 
+	// Apply response preprocessor if configured (e.g., to escape malformed XML)
+	rawXML := scrapligoRes.Result
+	if c.ResponsePreprocessor != nil {
+		rawXML = c.ResponsePreprocessor(rawXML)
+	}
+
 	// Parse XML with xmldot
-	result := xmldot.Get(scrapligoRes.Result, "rpc-reply")
+	result := xmldot.Get(rawXML, "rpc-reply")
 
 	// Check for <ok/> response
-	okResult := xmldot.Get(scrapligoRes.Result, "rpc-reply.ok")
+	okResult := xmldot.Get(rawXML, "rpc-reply.ok")
 	ok := okResult.Exists()
 
 	// Check for <rpc-error> elements
-	errors := c.parseRPCErrors(scrapligoRes.Result)
+	errors := c.parseRPCErrors(rawXML)
 
 	// Extract message-id
-	msgID := xmldot.Get(scrapligoRes.Result, "rpc-reply@message-id").String()
+	msgID := xmldot.Get(rawXML, "rpc-reply@message-id").String()
 
 	return Res{
 		Res:       result,

--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scrapli/scrapligo/response"
 	"github.com/scrapli/scrapligo/util"
 )
 
@@ -1590,6 +1591,145 @@ func TestClient_LockPollingBeyondMaxRetries(t *testing.T) {
 			if !shouldExit {
 				t.Errorf("attempt %d: non-transient error should exit immediately, but exit condition is false", attempt)
 			}
+		}
+	})
+}
+
+func TestResponsePreprocessor(t *testing.T) {
+	t.Run("preprocessor transforms XML before parsing", func(t *testing.T) {
+		// Simulate a NETCONF response with unescaped angle brackets in banner text.
+		// Without preprocessing, xmldot would treat "<contact:" as an XML tag.
+		rawXML := `<?xml version="1.0"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1">
+  <data>
+    <native>
+      <banner>
+        <login>
+          <banner>==> LOGIN <==</banner>
+        </login>
+      </banner>
+    </native>
+  </data>
+</rpc-reply>`
+
+		// Preprocessor escapes angle brackets inside <banner> text
+		preprocessor := func(xml string) string {
+			return strings.ReplaceAll(
+				strings.ReplaceAll(xml, "==>", "==&gt;"),
+				"<==", "&lt;==",
+			)
+		}
+
+		client := &Client{
+			logger:               &NoOpLogger{},
+			ResponsePreprocessor: preprocessor,
+		}
+
+		res, err := client.parseResponse(&response.NetconfResponse{
+			Result: rawXML,
+		})
+		if err != nil {
+			t.Fatalf("parseResponse returned error: %v", err)
+		}
+
+		// The preprocessed XML should parse correctly and preserve the angle brackets
+		loginBanner := res.Res.Get("data.native.banner.login.banner").String()
+		if !strings.Contains(loginBanner, "==>") {
+			t.Errorf("expected login banner to contain '==>', got %q", loginBanner)
+		}
+		if !strings.Contains(loginBanner, "<==") {
+			t.Errorf("expected login banner to contain '<==', got %q", loginBanner)
+		}
+	})
+
+	t.Run("nil preprocessor is a no-op", func(t *testing.T) {
+		rawXML := `<?xml version="1.0"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1">
+  <data>
+    <native>
+      <banner>
+        <motd>
+          <banner>Simple banner</banner>
+        </motd>
+      </banner>
+    </native>
+  </data>
+</rpc-reply>`
+
+		client := &Client{
+			logger:               &NoOpLogger{},
+			ResponsePreprocessor: nil,
+		}
+
+		res, err := client.parseResponse(&response.NetconfResponse{
+			Result: rawXML,
+		})
+		if err != nil {
+			t.Fatalf("parseResponse returned error: %v", err)
+		}
+
+		motdBanner := res.Res.Get("data.native.banner.motd.banner").String()
+		if motdBanner != "Simple banner" {
+			t.Errorf("expected 'Simple banner', got %q", motdBanner)
+		}
+	})
+
+	t.Run("preprocessor applied to ok response", func(t *testing.T) {
+		called := false
+		preprocessor := func(xml string) string {
+			called = true
+			return xml
+		}
+
+		client := &Client{
+			logger:               &NoOpLogger{},
+			ResponsePreprocessor: preprocessor,
+		}
+
+		res, err := client.parseResponse(&response.NetconfResponse{
+			Result: `<?xml version="1.0"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1">
+  <ok/>
+</rpc-reply>`,
+		})
+		if err != nil {
+			t.Fatalf("parseResponse returned error: %v", err)
+		}
+		if !called {
+			t.Error("expected preprocessor to be called")
+		}
+		if !res.OK {
+			t.Error("expected OK to be true")
+		}
+	})
+
+	t.Run("preprocessor applied to error response", func(t *testing.T) {
+		client := &Client{
+			logger: &NoOpLogger{},
+			ResponsePreprocessor: func(xml string) string {
+				return xml // pass-through
+			},
+		}
+
+		res, err := client.parseResponse(&response.NetconfResponse{
+			Result: `<?xml version="1.0"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1">
+  <rpc-error>
+    <error-type>application</error-type>
+    <error-tag>operation-failed</error-tag>
+    <error-severity>error</error-severity>
+    <error-message>Something went wrong</error-message>
+  </rpc-error>
+</rpc-reply>`,
+		})
+		if err != nil {
+			t.Fatalf("parseResponse returned error: %v", err)
+		}
+		if len(res.Errors) != 1 {
+			t.Fatalf("expected 1 error, got %d", len(res.Errors))
+		}
+		if res.Errors[0].ErrorMessage != "Something went wrong" {
+			t.Errorf("expected error message 'Something went wrong', got %q", res.Errors[0].ErrorMessage)
 		}
 	})
 }

--- a/options.go
+++ b/options.go
@@ -179,6 +179,24 @@ func WithPrettyPrintLogs(enabled bool) func(*Client) {
 	}
 }
 
+// WithResponsePreprocessor sets a function that transforms the raw XML response
+// string before it is parsed. This allows callers to sanitize malformed XML
+// from devices that don't properly escape special characters.
+//
+// The preprocessor receives the raw XML response and must return valid XML.
+//
+// Example (escape unescaped angle brackets in banner text):
+//
+//	client, _ := netconf.NewClient("192.168.1.1",
+//	    netconf.Username("admin"),
+//	    netconf.Password("secret"),
+//	    netconf.WithResponsePreprocessor(myBannerSanitizer))
+func WithResponsePreprocessor(fn func(string) string) func(*Client) {
+	return func(c *Client) {
+		c.ResponsePreprocessor = fn
+	}
+}
+
 // Request modifiers for individual operations
 
 // Timeout returns a request modifier that sets a custom timeout for the operation


### PR DESCRIPTION
## Summary

Adds an optional `ResponsePreprocessor` function to the `Client` that transforms
the raw NETCONF XML response string before it is parsed by xmldot.

## Problem

Some IOS-XE devices return malformed XML in NETCONF responses — specifically,
unescaped `<` and `>` characters in banner text content. For example:

```xml
<banner>==> LOGIN <==</banner>
```

The xmldot parser interprets `<==` as an XML tag start, corrupting the parsed
result (e.g., `==>` becomes `==`, `<contact: admin@example.com>` loses the
closing `>`). The device CLI stores these characters correctly — the issue is
only in the NETCONF XML encoding.

## Solution

A new `ResponsePreprocessor` field on the `Client` struct, set via the
`WithResponsePreprocessor()` functional option. When configured, the
preprocessor runs on the raw XML string before any `xmldot.Get()` calls
in `parseResponse()`.

This keeps the fix opt-in and caller-defined — the library doesn't make
assumptions about which XML elements need sanitization. The caller (e.g., the
Terraform provider) provides a function that knows which elements contain
text content that may have unescaped special characters.

### Usage

```go
client, err := netconf.NewClient(host,
    netconf.Username("admin"),
    netconf.Password("secret"),
    netconf.WithResponsePreprocessor(func(xml string) string {
        // Escape angle brackets in <banner> text elements
        return myBannerSanitizer(xml)
    }),
)
```

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~85%
- **AI Reason**: ResponsePreprocessor hook implementation + tests